### PR TITLE
Add light-mode

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -1,11 +1,21 @@
 /* general page styling */
 :root {
   --main-bg-color: #020404;
+  --main-bg-contrast-color: oklch(40% 0 0);
   --main-text-color: #efe3e3;
   --main-accent-color: #f9c827;
   --secondary-accent-color: #ff925f;
 
   scroll-behavior: smooth;
+}
+
+@media(prefers-color-scheme: light) {
+  :root {
+    --main-bg-color: #fdfbfb;
+    --main-bg-contrast-color: oklch(90% 0 0);
+    --main-text-color: #101c1c;
+    --main-accent-color: #836400;
+  }
 }
 
 * {
@@ -306,7 +316,7 @@ footer {
 
   .calendar-date th {
     padding: 0.5em 1em;
-    background: oklch(40% 0 0);
+    background: var(--main-bg-contrast-color);
   }
   td {
     padding: 1em;

--- a/static/main.css
+++ b/static/main.css
@@ -1,8 +1,8 @@
 /* general page styling */
 :root {
-  --main-bg-color: #020404;
+  --main-bg-color: oklch(1% 0 0);
   --main-bg-contrast-color: oklch(40% 0 0);
-  --main-text-color: #efe3e3;
+  --main-text-color: oklch(92% 0 none);
   --main-accent-color: #f9c827;
   --secondary-accent-color: #ff925f;
 
@@ -14,12 +14,13 @@
   scroll-behavior: smooth;
 }
 
-@media(prefers-color-scheme: light) {
+@media (prefers-color-scheme: light) {
   :root {
-    --main-bg-color: #fdfbfb;
+    --main-bg-color: oklch(99% 0 0);
     --main-bg-contrast-color: oklch(90% 0 0);
-    --main-text-color: #101c1c;
-    --main-accent-color: #836400;
+    --main-text-color: oklch(15% 0 0);
+    --main-accent-color: oklch(40.8% 0.074 45);
+    --secondary-accent-color: oklch(85.13% 0.1737 89.73);
   }
 }
 

--- a/static/main.css
+++ b/static/main.css
@@ -6,6 +6,11 @@
   --main-accent-color: #f9c827;
   --secondary-accent-color: #ff925f;
 
+  /* Tell browser that we support dark and light mode.
+     Allows browser to change UI elements to match the color scheme.
+     By default browser assume only light mode is supported and draw elements accordingly.
+     This for example includes the chrome scrollbar and default form elements. */
+  color-scheme: dark light;
   scroll-behavior: smooth;
 }
 

--- a/templates/page.html
+++ b/templates/page.html
@@ -56,6 +56,10 @@
       href="{{ get_url(path='logo.svg', trailing_slash=false) }}"
     />
 
+    <!-- Disables Dark Reader for this site.
+         We have our own dark-mode and dark reader mangles the page background. -->
+    <meta name="darkreader-lock">
+
     <link
       rel="stylesheet"
       href="{{ get_url(path='main.css', trailing_slash=false) }}"


### PR DESCRIPTION
Adds a light color scheme for the website, which is a nice-to-have for users who prefer light modes and a help/necessity for some visually impaired users which have trouble reading white-on-black text.

The accent color for the white scheme is a darker orange because the original CTBK orange would not provide enough contrast for WCAG compliance. This could also be changed to black which may look a bit nicer.

Also disables dark reader if it is installed. 
Darkreader would mangle with the page in both firefox and chromium resulting in two background colors. One from the body provided by the page css and the background color inside the `html` element overwritten by dark reader.